### PR TITLE
Adding Gunicorn server to run Django in heroku

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ django-crispy-forms==1.14.0
 django-environ==0.8.1
 djongo==1.3.6
 dnspython==2.2.1
+gunicorn==20.1.0
 oauthlib==3.2.0
 pymongo==3.12.3
 python3-openid==3.2.0


### PR DESCRIPTION
# Adding Gunicorn server to run Django in heroku

## Adding Gunicorn server to run Django in heroku:
- Bug fix for deployment error.
  - #34 
